### PR TITLE
CLI Interface Detailed Specification and Instructions Examples Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A multimodal AI story teller, built with [Stable Diffusion](https://huggingface.co/spaces/stabilityai/stable-diffusion), GPT, and neural text-to-speech (TTS).
+A multimodal AI storyteller, built with [Stable Diffusion](https://huggingface.co/spaces/stabilityai/stable-diffusion), GPT, and neural text-to-speech (TTS).
 
 Given a prompt as an opening line of a story, GPT writes the rest of the plot; Stable Diffusion draws an image for each sentence; a TTS model narrates each line, resulting in a fully animated video of a short story, replete with audio and visuals.
 
-![out](https://user-images.githubusercontent.com/25360440/210071764-51ed5872-ba56-4ed0-919b-d9ce65110185.gif)
+<img id="default-output" src="https://user-images.githubusercontent.com/25360440/210071764-51ed5872-ba56-4ed0-919b-d9ce65110185.gif" alt="Example output generated with the default prompt.">
 
 ## Installation
 
@@ -45,37 +45,56 @@ $ pre-commit install
 
 ## Quickstart
 
-The quickest way to run a demo is through the CLI. Simply type
+The quickest way to run a demo is by using the command line interface (CLI). To get started, simply type:
 
 ```
 $ storyteller
 ```
 
-The final video will be saved as `/out/out.mp4`, alongside other intermediate images, audio files, and subtitles.
+This command will initialize the story with the default prompt of `Once upon a time, unicorns roamed the Earth`. An
+example of the output that will be generated [can be seen in the animation above](#default-output).
+You can customize the beginning of your story by using the `--writer_prompt` argument. For example, if you would like to
+start your story with the text `The ravenous cat, driven by an insatiable craving for tuna, devised a daring plan to break into the local fish market's coveted tuna reserve.`, 
+your CLI command would look as follows:
 
-To adjust the defaults with custom parametes, toggle the CLI flags as needed.
+```
+storyteller --writer_prompt "The ravenous cat, driven by an insatiable craving for tuna, devised a daring plan to break into the local fish market's coveted tuna reserve."
+```
+
+The final video will be saved in the `/out/out.mp4` directory, along with other intermediate files such as images,
+audio files, and subtitles.
+
+To adjust the default settings with custom parameters, you can use the different CLI flags as needed. To see a list of 
+all available options, type:
 
 ```
 $ storyteller --help
-usage: storyteller [-h] [--writer_prompt WRITER_PROMPT]
-                   [--painter_prompt_prefix PAINTER_PROMPT_PREFIX] [--num_images NUM_IMAGES]
-                   [--output_dir OUTPUT_DIR] [--seed SEED] [--max_new_tokens MAX_NEW_TOKENS]
-                   [--writer WRITER] [--painter PAINTER] [--speaker SPEAKER]
-                   [--writer_device WRITER_DEVICE] [--painter_device PAINTER_DEVICE]
+```
 
-optional arguments:
+This will provide you with a list of the options, their descriptions and their defaults.
+
+
+```
+options:
   -h, --help            show this help message and exit
   --writer_prompt WRITER_PROMPT
+                        The prompt to be used for the writer model. This is the text with which your story will begin. Default: 'Once upon a time, unicorns roamed the Earth.'
   --painter_prompt_prefix PAINTER_PROMPT_PREFIX
+                        The prefix to be used for the painter model's prompt. Default: 'Beautiful painting'
   --num_images NUM_IMAGES
+                        The number of images to be generated. Those images will be composed in sequence into a video. Default: 10
   --output_dir OUTPUT_DIR
-  --seed SEED
+                        The directory to save the generated files to. Default: 'out'
+  --seed SEED           The seed value to be used for randomization. Default: 42
   --max_new_tokens MAX_NEW_TOKENS
-  --writer WRITER
-  --painter PAINTER
-  --speaker SPEAKER
+                        Maximum number of new tokens to generate in the writer model. Default: 50
+  --writer WRITER       Text generation model to use. Default: 'gpt2'
+  --painter PAINTER     Image generation model to use. Default: 'stabilityai/stable-diffusion-2'
+  --speaker SPEAKER     Text-to-speech (TTS) generation model. Default: 'tts_models/en/ljspeech/glow-tts'
   --writer_device WRITER_DEVICE
+                        Text generation device to use. Default: 'cpu'
   --painter_device PAINTER_DEVICE
+                        Image generation device to use. Default: 'cpu'
 ```
 
 ## Usage

--- a/src/storyteller/__init__.py
+++ b/src/storyteller/__init__.py
@@ -1,6 +1,6 @@
 from importlib import metadata
 
-from storyteller.config import StoryTellerConfig
+from storyteller.config import StoryTellerConfig, StoryTellerConfigArgparseHelpText
 from storyteller.model import StoryTeller
 
 __version__ = metadata.version("storyteller-core")

--- a/src/storyteller/cli.py
+++ b/src/storyteller/cli.py
@@ -3,8 +3,21 @@ import dataclasses
 import logging
 import os
 
-from storyteller import StoryTeller, StoryTellerConfig
+from storyteller import (
+    StoryTeller,
+    StoryTellerConfig,
+    StoryTellerConfigArgparseHelpText,
+)
 from storyteller.utils import set_log_level, set_seed
+
+
+class ArgparseDefaults:
+    WRITER_PROMPT: str = "Once upon a time, unicorns roamed the Earth."
+    PAINTER_PROMPT: str = "Beautiful painting"
+    OUTPUT_DIR: str = "out"
+
+    NUM_IMAGES: int = 10
+    SEED: int = 42
 
 
 def get_args() -> argparse.Namespace:
@@ -12,19 +25,42 @@ def get_args() -> argparse.Namespace:
     parser.add_argument(
         "--writer_prompt",
         type=str,
-        default="Once upon a time, unicorns roamed the Earth.",
+        default=ArgparseDefaults.WRITER_PROMPT,
+        help=f"The prompt to be used for the writer model. This is the text with which your story will begin. Default: '{ArgparseDefaults.WRITER_PROMPT}'",
     )
     parser.add_argument(
-        "--painter_prompt_prefix", type=str, default="Beautiful painting"
+        "--painter_prompt_prefix",
+        type=str,
+        default=ArgparseDefaults.PAINTER_PROMPT,
+        help=f"The prefix to be used for the painter model's prompt. Default: '{ArgparseDefaults.PAINTER_PROMPT}'",
     )
-    parser.add_argument("--num_images", type=int, default=10)
-    parser.add_argument("--output_dir", type=str, default="out")
-    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--num_images",
+        type=int,
+        default=ArgparseDefaults.NUM_IMAGES,
+        help=f"The number of images to be generated. Those images will be composed in sequence into a video. Default: {ArgparseDefaults.NUM_IMAGES}",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default=ArgparseDefaults.OUTPUT_DIR,
+        help=f"The directory to save the generated files to. Default: '{ArgparseDefaults.OUTPUT_DIR}'",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=ArgparseDefaults.SEED,
+        help=f"The seed value to be used for randomization. Default: {ArgparseDefaults.SEED}",
+    )
     default_config = StoryTellerConfig()
     for key, value in dataclasses.asdict(default_config).items():
-        parser.add_argument(f"--{key}", type=type(value), default=value)
-    args = parser.parse_args()
-    return args
+        parser.add_argument(
+            f"--{key}",
+            type=type(value),
+            default=value,
+            help=StoryTellerConfigArgparseHelpText.get_help_text_for_var_name(key),
+        )
+    return parser.parse_args()
 
 
 def main() -> None:

--- a/src/storyteller/config.py
+++ b/src/storyteller/config.py
@@ -1,13 +1,67 @@
+from __future__ import annotations
+
+import sys
 from dataclasses import dataclass
+from typing import Dict, Type
 
 import torch
 
 
+class StoryTellerConfigDefaults:
+    MAX_NEW_TOKENS: int = 50
+    WRITER_MODEL: str = "gpt2"
+    PAINTER_MODEL: str = "stabilityai/stable-diffusion-2"
+    SPEAKER_MODEL: str = "tts_models/en/ljspeech/glow-tts"
+    WRITER_DEVICE: str = "cuda:0" if torch.cuda.is_available() else "cpu"
+    PAINTER_DEVICE: str = "cuda:0" if torch.cuda.is_available() else "cpu"
+
+
 @dataclass
 class StoryTellerConfig:
-    max_new_tokens: int = 50
-    writer: str = "gpt2"
-    painter: str = "stabilityai/stable-diffusion-2"
-    speaker: str = "tts_models/en/ljspeech/glow-tts"
-    writer_device: str = "cuda:0" if torch.cuda.is_available() else "cpu"
-    painter_device: str = "cuda:0" if torch.cuda.is_available() else "cpu"
+    max_new_tokens: int = StoryTellerConfigDefaults.MAX_NEW_TOKENS
+    writer: str = StoryTellerConfigDefaults.WRITER_MODEL
+    painter: str = StoryTellerConfigDefaults.PAINTER_MODEL
+    speaker: str = StoryTellerConfigDefaults.SPEAKER_MODEL
+    writer_device: str = StoryTellerConfigDefaults.WRITER_DEVICE
+    painter_device: str = StoryTellerConfigDefaults.PAINTER_DEVICE
+
+
+class StoryTellerConfigArgparseHelpText:
+    @staticmethod
+    def _get_dataclass_var_name_from_f_string_eq(expression: str) -> str:
+        return expression.split(".")[1].split("=")[0]
+
+    # importing from typing for backwards compatibility
+    _argparse_help_text: Dict[str, str] = {
+        _get_dataclass_var_name_from_f_string_eq(
+            f"{StoryTellerConfig.max_new_tokens=}"
+        ): f"Maximum number of new tokens to generate in the writer model. Default: {StoryTellerConfigDefaults.MAX_NEW_TOKENS}",
+        _get_dataclass_var_name_from_f_string_eq(
+            f"{StoryTellerConfig.writer=}"
+        ): f"Text generation model to use. Default: '{StoryTellerConfigDefaults.WRITER_MODEL}'",
+        _get_dataclass_var_name_from_f_string_eq(
+            f"{StoryTellerConfig.painter=}"
+        ): f"Image generation model to use. Default: '{StoryTellerConfigDefaults.PAINTER_MODEL}'",
+        _get_dataclass_var_name_from_f_string_eq(
+            f"{StoryTellerConfig.speaker=}"
+        ): f"Text-to-speech (TTS) generation model. Default: '{StoryTellerConfigDefaults.SPEAKER_MODEL}'",
+        _get_dataclass_var_name_from_f_string_eq(
+            f"{StoryTellerConfig.writer_device=}"
+        ): f"Text generation device to use. Default: '{StoryTellerConfigDefaults.WRITER_DEVICE}'",
+        _get_dataclass_var_name_from_f_string_eq(
+            f"{StoryTellerConfig.painter_device=}"
+        ): f"Image generation device to use. Default: '{StoryTellerConfigDefaults.PAINTER_DEVICE}'",
+    }
+
+    @classmethod
+    def get_help_text_for_var_name(
+        cls: Type[StoryTellerConfigArgparseHelpText], var_name: str
+    ) -> str:
+        try:
+            return cls._argparse_help_text[var_name]
+        except KeyError:
+            print(
+                f"Warning: Helper text for {var_name} not found. Returning empty string.",
+                file=sys.stderr,
+            )
+            return ""


### PR DESCRIPTION
This Merge Request addresses issue https://github.com/jaketae/storyteller/issues/13 where the `storyteller --help` command does not provide enough information about the arguments. The argparse module is used to handle command-line arguments, but the descriptions and defaults were not added to the arguments.

To fix this issue, I have added detailed descriptions and default values to the arguments in the argparse code. In the process I have also refactored parts the code, which I have made more modular.

As a result, when running `storyteller --help`, the arguments will have clear descriptions and defaults, making it easier for users to understand how to use the command-line interface. I have also updated the documentation to reflect the changes made to the command-line interface. In addition, I have added a clearer example on how to run the demo using custom parameters in the `README`. 

I was not able to install the git pre-commit hooks, as the dev target appears to be missing. I did however, format the code using Black, as is mentioned in the repository description.